### PR TITLE
New variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 - allow other architectures to download
 - checksum as variable and for `cfssl` and `cfssljson` binary
+- add Archlinux as supported platform
 
 **3.0.0+1.2.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+**4.0.0+1.2.0**
+
+- allow other architectures to download
+- checksum as variable and for `cfssl` and `cfssljson` binary
+
 **3.0.0+1.2.0**
 
 - use correct semantic versioning as described in https://semver.org. Needed for Ansible Galaxy importer as it now insists on using semantic versioning.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,29 @@ Role Variables
 --------------
 
 ```
-#Specifies the version of CFSSL toolkit we want to download and use
+# Specifies the version of CFSSL toolkit we want to download and use
 cfssl_version: "R1.2"
+# Checksum of "cfssl" binary
+cfssl_checksum: "sha256:eb34ab2179e0b67c29fd55f52422a94fe751527b06a403a79325fed7cf0145bd"
+# Checksum of "cfssljson" binary
+cfssljson_checksum: "sha256:1c9e628c3b86c3f2f8af56415d474c9ed4c8f9246630bd21c3418dbe5bf6401e"
 # The directory where CFSSL binaries will be installed
 cfssl_bin_directory: "/usr/local/bin"
+# Owner of "cfssl/cfssljson" binary
+cfssl_owner: "root"
+# Group of "cfssl/cfssljson" binary
+cfssl_group: "root"
+# Operarting system on which "cfssl/cfssljson" should run on
+cfssl_os: "linux" # use "darwin" for MacOS X, "windows" for Windows
+# Processor architecture "cfssl/cfssljson" should run on
+cfssl_arch: "amd64" # other possible values: "386","arm64"
 ```
 
 Example Playbook
 ----------------
 
 ```
-- hosts: k8s_ca
+- hosts: cfssl-hosts
   roles:
     - githubixx.cfssl
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,18 @@
 ---
-#Specifies the version of CFSSL toolkit we want to download and use
+# Specifies the version of CFSSL toolkit we want to download and use
 cfssl_version: "R1.2"
+# Checksum of "cfssl" binary
+cfssl_checksum: "sha256:eb34ab2179e0b67c29fd55f52422a94fe751527b06a403a79325fed7cf0145bd"
+# Checksum of "cfssljson" binary
+cfssljson_checksum: "sha256:1c9e628c3b86c3f2f8af56415d474c9ed4c8f9246630bd21c3418dbe5bf6401e"
 # The directory where CFSSL binaries will be installed
 cfssl_bin_directory: "/usr/local/bin"
+# Owner of "cfssl/cfssljson" binary
+cfssl_owner: "root"
+# Group of "cfssl/cfssljson" binary
+cfssl_group: "root"
+# Operarting system on which "cfssl/cfssljson" should run on
+cfssl_os: "linux" # use "darwin" for MacOS X, "windows" for Windows
+# Processor architecture "cfssl/cfssljson" should run on
+cfssl_arch: "amd64" # other possible values: "386","arm64"
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,6 +7,7 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - xenial
+    - bionic
   galaxy_tags:
     - tls
     - certificate

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,6 +4,7 @@ galaxy_info:
   license: GPLv3
   min_ansible_version: 2.2
   platforms:
+  - name: ArchLinux
   - name: Ubuntu
     versions:
     - xenial

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,22 @@
 ---
 - name: Download statically linked cfssl binary
   get_url:
-    url: "https://pkg.cfssl.org/{{ cfssl_version }}/cfssl_linux-amd64"
+    url: "https://pkg.cfssl.org/{{ cfssl_version }}/cfssl_{{ cfssl_os }}-{{ cfssl_arch }}"
     dest: "{{ cfssl_bin_directory }}/cfssl"
     mode: 0755
-    checksum: sha256:eb34ab2179e0b67c29fd55f52422a94fe751527b06a403a79325fed7cf0145bd
+    owner: "{{ cfssl_owner }}"
+    group: "{{ cfssl_group }}"
+    checksum: "{{ cfssl_checksum }}"
   tags:
     - cfssl
 
 - name: Download statically linked cfssljson binary
   get_url:
-    url: "https://pkg.cfssl.org/{{ cfssl_version }}/cfssljson_linux-amd64"
+    url: "https://pkg.cfssl.org/{{ cfssl_version }}/cfssljson_{{ cfssl_os }}-{{ cfssl_arch }}"
     dest: "{{ cfssl_bin_directory }}/cfssljson"
+    owner: "{{ cfssl_owner }}"
+    group: "{{ cfssl_group }}"
+    checksum: "{{ cfssljson_checksum }}"
     mode: 0755
   tags:
     - cfssl


### PR DESCRIPTION
- allow other architectures to download
- checksum as variable and for `cfssl` and `cfssljson` binary
- add Archlinux as supported platform
