### PR TITLE
8.0.1+1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **8.0.1+1.6.2**
 
 - Update `cfssl` tools to version 1.6.2
+- tasks/main.yml: use FQDN Ansible module name
+-  meta/main.yml: update `min_ansible_version` to `2.9` / add `role_name` and `namespace`
 
 **8.0.0+1.6.1**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**8.0.1+1.6.2**
+
+- Update `cfssl` tools to version 1.6.2
+
 **8.0.0+1.6.1**
 
 - Update `cfssl` tools to version 1.6.1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Versions
 
 I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too.
 
-The tag `7.1.0+1.6.0` means that this is the release `7.1.0` of the Ansible role which uses release `1.6.0` of CFSSL.
+The tag `8.0.1+1.6.2` means that this is the release `8.0.1` of the Ansible role which uses release `1.6.2` of CFSSL.
 
 Changelog
 ---------
@@ -20,7 +20,7 @@ Role Variables
 
 ```
 # Specifies the version of CFSSL toolkit we want to download and use
-cfssl_version: "1.6.1"
+cfssl_version: "1.6.2"
 
 # Checksum file
 cfssl_checksum_url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssl_{{ cfssl_version }}_checksums.txt"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Specifies the version of CFSSL toolkit we want to download and use
-cfssl_version: "1.6.1"
+cfssl_version: "1.6.2"
 
 # Checksum file
 cfssl_checksum_url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssl_{{ cfssl_version }}_checksums.txt"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,11 @@
+---
 galaxy_info:
   author: Robert Wimmer
   description: Installs CFSSL PKI toolkit
   license: GPLv3
-  min_ansible_version: 2.7
+  min_ansible_version: "2.9"
+  role_name: cfssl
+  namespace: githubixx
   platforms:
     - name: ArchLinux
     - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Downloading cfssl binaries
-  get_url:
+  ansible.builtin.get_url:
     url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/{{ item }}_{{ cfssl_version }}_{{ cfssl_os }}_{{ cfssl_arch }}"
     dest: "{{ cfssl_bin_directory }}/{{ item }}"
     mode: 0755


### PR DESCRIPTION
- Update `cfssl` tools to version `1.6.2`
- tasks/main.yml: use FQDN Ansible module name
-  meta/main.yml: update `min_ansible_version` to `2.9` / add `role_name` and `namespace`