### PR TITLE
8.2.0+1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**8.1.1+1.6.4**
+
+- Update `cfssl` tools to version 1.6.4
+
 **8.1.0+1.6.3**
 
 - Update `cfssl` tools to version 1.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 Changelog
 ---------
 
-**8.1.1+1.6.4**
+**8.2.0+1.6.4**
 
 - Update `cfssl` tools to version 1.6.4
+- Add support for Ubuntu 22.04
+- Add verify step for Molecule
 
 **8.1.0+1.6.3**
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Versions
 
 I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too.
 
-The tag `8.0.2+1.6.3` means that this is the release `8.0.2` of the Ansible role which uses release `1.6.3` of CFSSL.
+The tag `8.1.1+1.6.4` means that this is the release `8.1.1` of the Ansible role which uses release `1.6.4` of CFSSL.
 
 Changelog
 ---------
@@ -20,7 +20,7 @@ Role Variables
 
 ```
 # Specifies the version of CFSSL toolkit we want to download and use
-cfssl_version: "1.6.3"
+cfssl_version: "1.6.4"
 
 # Checksum file
 cfssl_checksum_url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssl_{{ cfssl_version }}_checksums.txt"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Specifies the version of CFSSL toolkit we want to download and use
-cfssl_version: "1.6.3"
+cfssl_version: "1.6.4"
 
 # Checksum file
 cfssl_checksum_url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssl_{{ cfssl_version }}_checksums.txt"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,12 +10,13 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - bionic
-        - focal
+        - "bionic"
+        - "focal"
+        - "jammy"
     - name: Debian
       versions:
-        - buster
-        - bullseye
+        - "buster"
+        - "bullseye"
   galaxy_tags:
     - tls
     - certificate

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,9 @@ lint: |
   ansible-lint .
 
 platforms:
+  - name: test-cfssl-ubuntu2204
+    image: ubuntu:22.04
+    pre_build_image: true
   - name: test-cfssl-ubuntu2004
     image: ubuntu:20.04
     pre_build_image: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify setup
+  hosts: all
+  vars:
+    expected_output: "1.6."
+  tasks:
+    - name: Execute cfssl version to capture output
+      ansible.builtin.command:
+        cmd: cfssl version
+      register: cfssl_version_output
+      changed_when: false
+
+    - name: Ensure cfssl version output contains correct version string
+      ansible.builtin.assert:
+        that:
+          - "expected_output in cfssl_version_output.stdout"


### PR DESCRIPTION
- Update `cfssl` tools to version 1.6.4
- Add support for Ubuntu 22.04
- Add verify step for Molecule