### PR TITLE
8.3.0+1.6.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,4 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 ## 8.3.0+1.6.5
 
-- Update `cfssl` tools to version 1.6.5
+- **BREAKING**
+  - remove Ubuntu 18.04 support (reached EOL)
+  - remove Debian 10 support (reached EOL)
+
+- **UPDATE**
+  - Update `cfssl` tools to version 1.6.5
+  - add Debian 12 support
+
+- **MOLECULE**
+  - fix ansible-lint issues in `converge.yml`
 
 ## 8.2.0+1.6.4
 
-- Update `cfssl` tools to version 1.6.4
-- Add support for Ubuntu 22.04
-- Add verify step for Molecule
+- **UPDATE**
+  - Update `cfssl` tools to version 1.6.4
+  - Add support for Ubuntu 22.04
+  - Add verify step for Molecule
 
 ## 8.1.0+1.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.3.0+1.6.5
+
+- Update `cfssl` tools to version 1.6.5
+
 ## 8.2.0+1.6.4
 
 - Update `cfssl` tools to version 1.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,94 +1,93 @@
-Changelog
----------
+# Changelog
 
-**8.2.0+1.6.4**
+## 8.2.0+1.6.4
 
 - Update `cfssl` tools to version 1.6.4
 - Add support for Ubuntu 22.04
 - Add verify step for Molecule
 
-**8.1.0+1.6.3**
+## 8.1.0+1.6.3
 
 - Update `cfssl` tools to version 1.6.3
 - add Github release action to push new release to Ansible Galaxy
 - add `.yamllint`
 
-**8.0.1+1.6.2**
+## 8.0.1+1.6.2
 
 - Update `cfssl` tools to version 1.6.2
 - tasks/main.yml: use FQDN Ansible module name
 - meta/main.yml: update `min_ansible_version` to `2.9` / add `role_name` and `namespace`
 
-**8.0.0+1.6.1**
+## 8.0.0+1.6.1
 
 - Update `cfssl` tools to version 1.6.1
 - Add support for Debian 10 (Buster) + 11 (Bullseye)
 - Remove Ubuntu 16.04 (Xenial) support
 
-**7.1.0+1.6.0**
+## 7.1.0+1.6.0
 
 - Update `cfssl` tools to version 1.6.0
 
-**7.0.0+1.5.0**
+## 7.0.0+1.5.0
 
 - Update `cfssl` tools to version 1.5.0
 - Added molecule test
 
-**6.0.0+1.4.1**
+## 6.0.0+1.4.1
 
 - Update `cfssl` tools to version 1.4.1
 
-**6.0.0+1.4.0**
+## 6.0.0+1.4.0
 
-- Renamed `chssl_checksum_url` to `cfssl_checksum_url`
+- Renamed `cfssl_checksum_url` to `cfssl_checksum_url`
 
-**5.0.1+1.4.0**
+## 5.0.1+1.4.0
 
 - Role requires Ansible version >= 2.7 now
 
-**5.0.0+1.4.0**
+## 5.0.0+1.4.0
 
 - Update `cfssl` tools to version 1.4.0
 - Since Cloudflare changed the way how to distribute binaries it's no longer possible to use `cfssl` binaries before version 1.4.0. If you need older binaries you can clone this Github repository and checkout `v4.0.0+1.2.0` branch
 - Added new binaries: `cfssl-bundle`,`cfssl-certinfo`,`cfssl-newkey`,`cfssl-scan`, `mkbundle` and `multirootca`
 - `cfssl_version` changed to `1.4.0`
-- `cfssl_checksum` and `cfssljson_checksum` variables removed as they're no longer needed (replaced by `chssl_checksum_url`)
-- `chssl_checksum_url` specifies the URL to a file that contains the SHA256 checksums for the various `cfssl` binaries
+- `cfssl_checksum` and `cfssljson_checksum` variables removed as they're no longer needed (replaced by `cfssl_checksum_url`)
+- `cfssl_checksum_url` specifies the URL to a file that contains the SHA256 checksums for the various `cfssl` binaries
 - `cfssl_arch` variable only supports `amd64` at the moment. Other architectures no longer supported
 
-**Tags removed - no functionality change**
+## Tags removed - no functionality change
 
 - Removed all tags before `3.0.0+1.2.0`. That was needed because Ansible Galaxy don't work with version tags that don't respect semantic versioning scheme (SemVer)
 
-**4.0.0+1.2.0**
+## 4.0.0+1.2.0
 
 - allow other architectures to download
 - checksum as variable and for `cfssl` and `cfssljson` binary
 - add Archlinux as supported platform
 
-**3.0.0+1.2.0**
+## 3.0.0+1.2.0
 
-- use correct semantic versioning as described in https://semver.org. Needed for Ansible Galaxy importer as it now insists on using semantic versioning.
+- use correct semantic versioning as described in [semver](https://semver.org). Needed for Ansible Galaxy importer as it now insists on using semantic versioning.
 - moved changelog entries to separate file
 - make Ansible linter happy
 - no major changes but decided to start a new major release as versioning scheme changed quite heavily
 
-**v2.0.3_r1.2.0**
+## v2.0.3_r1.2.0
 
 - update README
 
-**v2.0.2_r1.2.0**
+## v2.0.2_r1.2.0
 
 - update documentation of variables / update README
 
-**v2.0.1_r1.2.0**
+## v2.0.1_r1.2.0
 
 - variable values should be strings
 
-**v2.0.0_r1.2.0**
+## v2.0.0_r1.2.0
 
 - removed `cfssl_conf_directory` variable (not needed as this role only installs the CFSSL binaries)
 
-**v1.0.0_r1.2.0**
+## v1.0.0_r1.2.0
 
 - initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **UPDATE**
   - Update `cfssl` tools to version 1.6.5
   - add Debian 12 support
+  - update Github workflow
 
 - **MOLECULE**
   - fix ansible-lint issues in `converge.yml`

--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-cfssl/blob/mas
 
 ## 8.3.0+1.6.5
 
-- Update `cfssl` tools to version 1.6.5
+- **BREAKING**
+  - remove Ubuntu 18.04 support (reached EOL)
+  - remove Debian 10 support (reached EOL)
+
+- **UPDATE**
+  - Update `cfssl` tools to version 1.6.5
+  - add Debian 12 support
+
+- **MOLECULE**
+  - fix ansible-lint issues in `converge.yml`
 
 ## 8.2.0+1.6.4
 
-- Update `cfssl` tools to version 1.6.4
-- Add support for Ubuntu 22.04
-- Add verify step for Molecule
+- **UPDATE**
+  - Update `cfssl` tools to version 1.6.4
+  - Add support for Ubuntu 22.04
+  - Add verify step for Molecule
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,40 @@ The tag `8.3.0+1.6.5` means that this is the release `8.3.0` of the Ansible role
 
 ## Changelog
 
-see [CHANGELOG.md](https://github.com/githubixx/ansible-role-cfssl/blob/master/CHANGELOG.md)
+**Change history:**
+
+See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-cfssl/blob/master/CHANGELOG.md)
+
+**Recent changes:**
+
+## 8.3.0+1.6.5
+
+- Update `cfssl` tools to version 1.6.5
+
+## 8.2.0+1.6.4
+
+- Update `cfssl` tools to version 1.6.4
+- Add support for Ubuntu 22.04
+- Add verify step for Molecule
+
+## Installation
+
+- Directly download from Github (Change into Ansible roles directory before cloning. You can figure out the role path by using `ansible-config dump | grep DEFAULT_ROLES_PATH` command):
+`git clone https://github.com/githubixx/ansible-role-cfssl.git githubixx.cfssl`
+
+- Via `ansible-galaxy` command and download directly from Ansible Galaxy:
+`ansible-galaxy install role githubixx.cfssl`
+
+- Create a `requirements.yml` file with the following content (this will download the role from Github) and install with
+`ansible-galaxy role install -r requirements.yml` (change `version` if needed):
+
+```yaml
+---
+roles:
+  - name: githubixx.cfssl
+    src: https://github.com/githubixx/ansible-role-cfssl.git
+    version: 8.3.0+1.6.5
+```
 
 ## Role Variables
 
@@ -76,4 +109,4 @@ GNU GENERAL PUBLIC LICENSE Version 3
 
 ## Author Information
 
-http://www.tauceti.blog
+[http://www.tauceti.blog](http://www.tauceti.blog)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-cfssl/blob/mas
 - **UPDATE**
   - Update `cfssl` tools to version 1.6.5
   - add Debian 12 support
+  - update Github workflow
 
 - **MOLECULE**
   - fix ansible-lint issues in `converge.yml`

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
-ansible-role-cfssl
-==================
+# ansible-role-cfssl
 
 Installes CFSSL (CloudFlare's PKI toolkit) binaries. I used it as a lightweight certificate authority (CA) for Kubernetes. This Ansible playbook is used in [Kubernetes the not so hard way with Ansible - certificate authority](https://www.tauceti.blog/posts/kubernetes-the-not-so-hard-way-with-ansible-certificate-authority/).
 
-Versions
---------
+## Versions
 
 I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too.
 
 The tag `8.1.1+1.6.4` means that this is the release `8.1.1` of the Ansible role which uses release `1.6.4` of CFSSL.
 
-Changelog
----------
+## Changelog
 
 see [CHANGELOG.md](https://github.com/githubixx/ansible-role-cfssl/blob/master/CHANGELOG.md)
 
-Role Variables
---------------
+## Role Variables
 
-```
+```yaml
 # Specifies the version of CFSSL toolkit we want to download and use
 cfssl_version: "1.6.4"
 
@@ -34,28 +30,27 @@ cfssl_owner: "root"
 # Group of cfssl binaries
 cfssl_group: "root"
 
-# Operarting system on which "cfssl/cfssljson" should run on
+# Operating system on which "cfssl/cfssljson" should run on
 cfssl_os: "linux" # use "darwin" for MacOS X, "windows" for Windows
 
 # Processor architecture "cfssl/cfssljson" should run on
 cfssl_arch: "amd64" # the only supported architecture at the moment
 ```
 
-Testing
--------
+## Testing
 
 This role has a small test setup that is created using [molecule](https://github.com/ansible-community/molecule). To run the tests follow the molecule [install guide](https://molecule.readthedocs.io/en/latest/installation.html). Also ensure that a Docker daemon runs on your machine.
 
 Assuming [Docker](https://www.docker.io) is already installed you need at least two Python packages:
 
-```
+```bash
 pip3 install --user molecule
 pip3 install --user molecule-docker
 ```
 
 Afterwards molecule can be executed:
 
-```
+```bash
 molecule converge
 ```
 
@@ -63,25 +58,22 @@ This will setup some Docker container with Ubuntu 18.04/20.04 and Debian 10/11 w
 
 To clean up run
 
-```
+```bash
 molecule destroy
 ```
 
-Example Playbook
-----------------
+## Example Playbook
 
-```
+```yaml
 - hosts: cfssl-hosts
   roles:
     - githubixx.cfssl
 ```
 
-License
--------
+## License
 
 GNU GENERAL PUBLIC LICENSE Version 3
 
-Author Information
-------------------
+## Author Information
 
 http://www.tauceti.blog

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installes CFSSL (CloudFlare's PKI toolkit) binaries. I used it as a lightweight 
 
 I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too.
 
-The tag `8.1.1+1.6.4` means that this is the release `8.1.1` of the Ansible role which uses release `1.6.4` of CFSSL.
+The tag `8.3.0+1.6.5` means that this is the release `8.3.0` of the Ansible role which uses release `1.6.5` of CFSSL.
 
 ## Changelog
 
@@ -16,7 +16,7 @@ see [CHANGELOG.md](https://github.com/githubixx/ansible-role-cfssl/blob/master/C
 
 ```yaml
 # Specifies the version of CFSSL toolkit we want to download and use
-cfssl_version: "1.6.4"
+cfssl_version: "1.6.5"
 
 # Checksum file
 cfssl_checksum_url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssl_{{ cfssl_version }}_checksums.txt"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Specifies the version of CFSSL toolkit we want to download and use
-cfssl_version: "1.6.4"
+cfssl_version: "1.6.5"
 
 # Checksum file
 cfssl_checksum_url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssl_{{ cfssl_version }}_checksums.txt"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ cfssl_owner: "root"
 # Group of cfssl binaries
 cfssl_group: "root"
 
-# Operarting system on which "cfssl/cfssljson" should run on
+# Operating system on which "cfssl/cfssljson" should run on
 cfssl_os: "linux"    # use "darwin" for MacOS X, "windows" for Windows
 
 # Processor architecture "cfssl/cfssljson" should run on

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "bionic"
         - "focal"
         - "jammy"
     - name: Debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
         - "jammy"
     - name: Debian
       versions:
+        - "bookworm"
         - "bullseye"
   galaxy_tags:
     - tls

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,6 @@ galaxy_info:
         - "jammy"
     - name: Debian
       versions:
-        - "buster"
         - "bullseye"
   galaxy_tags:
     - tls

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,17 +1,20 @@
 ---
-- hosts: all
+- name: Setup cfssl
+  hosts: all
   gather_facts: false
   tasks:
     - name: Install Python
-      raw: |
+      ansible.builtin.raw: |
         apt-get update
         apt-get -y install ca-certificates python3
+      register: result
       changed_when: false
-      ignore_errors: true
+      failed_when:
+        - result.rc != 0
 
     - name: Call setup
-      setup:
+      ansible.builtin.setup:
 
     - name: Include cfssl role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.cfssl

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,11 +17,8 @@ platforms:
   - name: test-cfssl-ubuntu2004
     image: ubuntu:20.04
     pre_build_image: true
-  - name: test-cfssl-ubuntu1804
-    image: ubuntu:18.04
-    pre_build_image: true
-  - name: test-cfssl-debian10
-    image: debian:10
+  - name: test-cfssl-debian12
+    image: debian:12
     pre_build_image: true
   - name: test-cfssl-debian11
     image: debian:11


### PR DESCRIPTION
- **BREAKING**
  - remove Ubuntu 18.04 support (reached EOL)
  - remove Debian 10 support (reached EOL)

- **UPDATE**
  - Update `cfssl` tools to version 1.6.5
  - add Debian 12 support
  - update Github workflow

- **MOLECULE**
  - fix ansible-lint issues in `converge.yml`